### PR TITLE
Fixed to work along django-registration.

### DIFF
--- a/emailusernames/backends.py
+++ b/emailusernames/backends.py
@@ -14,6 +14,7 @@ class EmailAuthBackend(object):
         try:
             user = get_user(email)
             if user.check_password(password):
+                user.backend = "%s.%s" % (self.__module__, self.__class__.__name__)
                 return user
         except User.DoesNotExist:
             return None


### PR DESCRIPTION
When working with django-registration the django.contrib.auth.login will fail complaining about backend not being an User field.
