### PR TITLE
Fixes "The given username must be set" problem in Django 1.4

### DIFF
--- a/emailusernames/utils.py
+++ b/emailusernames/utils.py
@@ -42,7 +42,7 @@ def create_user(email, password=None, is_staff=None, is_active=None):
     Use this instead of `User.objects.create_user`.
     """
     try:
-        user = User.objects.create_user(None, email, password)
+        user = User.objects.create_user(email, email, password)
     except IntegrityError, err:
         if err.message == 'column username is not unique':
             raise IntegrityError('user email is not unique')


### PR DESCRIPTION
Just a small hotfix for upcoming Django 1.4.

Since commit 17628 django/django@5690b363c1b200ee1e390f184fa2a2c7d0a9681d `models.UserManager.create_user` The username parameter is now checked for emptiness and raises a `ValueError` in case of a negative result.
