### PR TITLE
Emails should support Internationalized domain names

### DIFF
--- a/emailusernames/utils.py
+++ b/emailusernames/utils.py
@@ -2,7 +2,6 @@ import base64
 import hashlib
 import os
 import sys
-import unicodedata
 
 from django.contrib.auth.models import User
 from django.db import IntegrityError
@@ -14,8 +13,7 @@ from django.db import IntegrityError
 # arbitrary emails.
 def _email_to_username(email):
     email = email.lower()  # Emails should be case-insensitive unique
-    email = unicodedata.normalize('NFKD', email).encode('ascii', 'ignore') # Emails should support IDN and be IDN unique
-    return base64.urlsafe_b64encode(hashlib.sha256(email.digest())[:30]
+    return base64.urlsafe_b64encode(hashlib.sha256(email.encode('utf8', 'ignore').digest())[:30]
 
 
 def get_user(email, queryset=None):


### PR DESCRIPTION
Django has supported emails containing IDN since 1.2.

I am not sure if this is the right way to fix, but it works for me.

Test emails:
- test@skóli.is,
- test@skólabær.is,
- test@sjóður.is.
