### PR TITLE
Updated auto-focus to id_email

### DIFF
--- a/emailusernames/templates/email_usernames/login.html
+++ b/emailusernames/templates/email_usernames/login.html
@@ -52,7 +52,7 @@
 </form>
 
 <script type="text/javascript">
-document.getElementById('id_username').focus()
+document.getElementById('id_email').focus()
 </script>
 </div>
 {% endblock %}


### PR DESCRIPTION
Hey,

I just noticed that the JavaScript in the login.html template tries to auto-focus into a field called id_username, so I changed it to id_email.
