### PR TITLE
Changed field ordering in auth form

### DIFF
--- a/emailusernames/forms.py
+++ b/emailusernames/forms.py
@@ -23,6 +23,7 @@ class EmailAuthenticationForm(AuthenticationForm):
     def __init__(self, request=None, *args, **kwargs):
         super(EmailAuthenticationForm, self).__init__(request, *args, **kwargs)
         del self.fields['username']
+        self.fields.keyOrder = ['email', 'password']
 
     def clean(self):
         email = self.cleaned_data.get('email')


### PR DESCRIPTION
As the email field is not normally present in Django's `AuthenticationForm`, it is positioned last when the form 
is displayed. A display like that is cumbersome as users are used to provide their email first during login.
