### PR TITLE
EmailAuthBackend inherits from ModelBackend

### DIFF
--- a/emailusernames/backends.py
+++ b/emailusernames/backends.py
@@ -8,8 +8,6 @@ class EmailAuthBackend(ModelBackend):
 
     """Allow users to log in with their email address"""
 
-    supports_inactive_user = True
-
     def authenticate(self, email=None, password=None):
         try:
             user = get_user(email)


### PR DESCRIPTION
I would think the supports_\* can be the same as for ModelBackend  now since the same stuff is going on there, e.g. checks for anonymous users etc.
What do you think?
