### PR TITLE
Fix handling of invalid email-format in createsuperuser command

### DIFF
--- a/emailusernames/management/commands/createsuperuser.py
+++ b/emailusernames/management/commands/createsuperuser.py
@@ -62,6 +62,7 @@ class Command(BaseCommand):
                     except exceptions.ValidationError:
                         sys.stderr.write("Error: That e-mail address is invalid.\n")
                         email = None
+                        continue
 
                     try:
                         get_user(email)


### PR DESCRIPTION
When entering a invalid email-address in the createsuperuser command, I get this:

```
$ python manage.py createsuperuser
E-mail address: admin
Error: That e-mail address is invalid.
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/ddog/Data/python/emailusername/project/venv/lib/python2.6/site-packages/django/core/management/__init__.py", line 443, in execute_from_command_line
    utility.execute()
  File "/Users/ddog/Data/python/emailusername/project/venv/lib/python2.6/site-packages/django/core/management/__init__.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/ddog/Data/python/emailusername/project/venv/lib/python2.6/site-packages/django/core/management/base.py", line 196, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/Users/ddog/Data/python/emailusername/project/venv/lib/python2.6/site-packages/django/core/management/base.py", line 232, in execute
    output = self.handle(*args, **options)
  File "/Users/ddog/Data/python/emailusername/emailusernames/management/commands/createsuperuser.py", line 67, in handle
    get_user(email)
  File "/Users/ddog/Data/python/emailusername/emailusernames/utils.py", line 29, in get_user
    return queryset.get(username=_email_to_username(email))
  File "/Users/ddog/Data/python/emailusername/emailusernames/utils.py", line 16, in _email_to_username
    email = email.lower()
AttributeError: 'NoneType' object has no attribute 'lower'
```

Adding a continue-statement when an invalid email is encountered fixes this.
