### PR TITLE
Override dumpdata command to un-monkeypatch User model before dumping

### DIFF
--- a/emailusernames/management/commands/dumpdata.py
+++ b/emailusernames/management/commands/dumpdata.py
@@ -1,0 +1,14 @@
+from django.core.management.commands import dumpdata
+from emailusernames.models import unmonkeypatch_user
+
+
+class Command(dumpdata.Command):
+
+    """
+    Override the built-in dumpdata command to un-monkeypatch the User
+    model before dumping, to allow usernames to be dumped correctly
+    """
+
+    def handle(self, *args, **kwargs):
+        unmonkeypatch_user()
+        return super(Command, self).handle(*args, **kwargs)

--- a/emailusernames/models.py
+++ b/emailusernames/models.py
@@ -21,8 +21,22 @@ def user_save_patch(self, *args, **kwargs):
     self.username = self.email
 
 
-User.__init__ = user_init_patch
-User.save_base = user_save_patch
+original_init = User.__init__
+original_save_base = User.save_base
+
+
+def monkeypatch_user():
+    User.__init__ = user_init_patch
+    User.save_base = user_save_patch
+
+
+def unmonkeypatch_user():
+    User.__init__ = original_init
+    User.save_base = original_save_base
+
+
+monkeypatch_user()
+
 
 # Monkey-path the admin site to use a custom login form
 AdminSite.login_form = EmailAdminAuthenticationForm


### PR DESCRIPTION
See issue #26

This patch adds more un-monkeypatching nastiness to undo the existing monkeypatching nastiness. Nasty.

... but it seems to work.

I haven't added any tests. I did try, but the fact that some of the tests require the monkeypatched model and some required the unmonkeypatched version seemed to screw things up. If anyone can suggest a way to test this, please let me know.
