### PR TITLE
Make Django's contrib.auth tests work

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Set `EmailAuthBackend` as your authentication backend:
 
     AUTHENTICATION_BACKENDS = (
         'emailusernames.backends.EmailAuthBackend',
+        # Uncomment the following to make Django tests pass:
+        # 'django.contrib.auth.backends.ModelBackend',
     )
 
 

--- a/emailusernames/management/commands/createsuperuser.py
+++ b/emailusernames/management/commands/createsuperuser.py
@@ -90,6 +90,13 @@ class Command(BaseCommand):
                 sys.stderr.write("\nOperation cancelled.\n")
                 sys.exit(1)
 
-        create_superuser(email, password)
+        # Make Django's tests work by accepting a username through
+        # call_command() but not through manage.py
+        username = options.get('username', None)
+        if username is None:
+            create_superuser(email, password)
+        else:
+            User.objects.create_superuser(username, email, password)
+
         if verbosity >= 1:
             self.stdout.write("Superuser created successfully.\n")

--- a/emailusernames/utils.py
+++ b/emailusernames/utils.py
@@ -41,6 +41,12 @@ def user_exists(email, queryset=None):
     return True
 
 
+_DUPLICATE_USERNAME_ERRORS = (
+    'column username is not unique',
+    'duplicate key value violates unique constraint "auth_user_username_key"\n'
+)
+
+
 def create_user(email, password=None, is_staff=None, is_active=None):
     """
     Create a new user with the given email.
@@ -49,7 +55,7 @@ def create_user(email, password=None, is_staff=None, is_active=None):
     try:
         user = User.objects.create_user(email, email, password)
     except IntegrityError, err:
-        if err.message == 'column username is not unique':
+        if err.message in _DUPLICATE_USERNAME_ERRORS:
             raise IntegrityError('user email is not unique')
         raise
 


### PR DESCRIPTION
Non-hashed usernames and fetching by usernames still work, if the program
does everything through the standard User model. This makes Django's
built-in contrib.auth tests function.
