### PR TITLE
Fix templatetag compatibility with Django 1.5

### DIFF
--- a/emailusernames/templates/email_usernames/login.html
+++ b/emailusernames/templates/email_usernames/login.html
@@ -1,9 +1,7 @@
-{% extends "admin/base_site.html" %}
+{% extends "admin/login.html" %}
 {% load i18n %}
-{% load static %}
 
-{% block extrastyle %}{% load adminmedia %}{{ block.super }}
-<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}admin/css/login.css" />
+{% block extrastyle %}{{ block.super }}
 <style type="text/css">
   .login .form-row #id_email {
     width: 14em;
@@ -11,18 +9,10 @@
 </style>
 {% endblock %}
 
-{% block bodyclass %}login{% endblock %}
-
-{% block nav-global %}{% endblock %}
-
-{% block content_title %}{% endblock %}
-
-{% block breadcrumbs %}{% endblock %}
-
 {% block content %}
 {% if form.errors and not form.non_field_errors and not form.this_is_the_login_form.errors %}
 <p class="errornote">
-{% blocktrans count form.errors.items|length as counter %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktrans %}
+{% blocktrans count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktrans %}
 </p>
 {% endif %}
 
@@ -46,6 +36,12 @@
     <input type="hidden" name="this_is_the_login_form" value="1" />
     <input type="hidden" name="next" value="{{ next }}" />
   </div>
+  {% url 'admin_password_reset' as password_reset_url %}
+  {% if password_reset_url %}
+  <div class="password-reset-link">
+    <a href="{{ password_reset_url }}">{% trans 'Forgotten your password or username?' %}</a>
+  </div>
+  {% endif %}
   <div class="submit-row">
     <label>&nbsp;</label><input type="submit" value="{% trans 'Log in' %}" />
   </div>


### PR DESCRIPTION
Django 1.3 introduced the _staticfiles application_ and since Django 1.5 `adminmedia.py` is no longer present in `django.contrib.admin.templatetags`. The use of `{% STATIC %}` from
`django.contrib.admin.templatetags.admin_static` is required.

See also https://docs.djangoproject.com/en/dev/releases/1.4/#django-contrib-admin 
and https://docs.djangoproject.com/en/dev/releases/1.5/#miscellaneous
