### PR TITLE
utils.py: _DUPLICATE_USERNAME_ERRORS matches beginning of IntegrityErrors

### DIFF
--- a/emailusernames/utils.py
+++ b/emailusernames/utils.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import os
+import re
 import sys
 
 from django.contrib.auth.models import User
@@ -55,7 +56,8 @@ def create_user(email, password=None, is_staff=None, is_active=None):
     try:
         user = User.objects.create_user(email, email, password)
     except IntegrityError, err:
-        if err.message in _DUPLICATE_USERNAME_ERRORS:
+        regexp = '|'.join(re.escape(e) for e in _DUPLICATE_USERNAME_ERRORS)
+        if re.match(regexp, err.message):
             raise IntegrityError('user email is not unique')
         raise
 


### PR DESCRIPTION
PostgreSQL 9.1 now spits out more descriptive errors, so we should move
to an re match instead of a simple string match.
