### PR TITLE
Authenticate should use `username` kwarg if no email is provided.

### DIFF
--- a/emailusernames/backends.py
+++ b/emailusernames/backends.py
@@ -10,9 +10,9 @@ class EmailAuthBackend(ModelBackend):
 
     def authenticate(self, email=None, password=None, **kwargs):
         # Some authenticators expect to authenticate by 'username'
-        if kwargs.get('username'):
-            email = kwargs['username']
-            
+        if email is None:
+            email = kwargs.get('username')
+
         try:
             user = get_user(email)
             if user.check_password(password):

--- a/emailusernames/tests.py
+++ b/emailusernames/tests.py
@@ -47,6 +47,10 @@ class ExistingUserTests(TestCase):
     def test_user_can_authenticate_with_username_parameter(self):
         auth = authenticate(username=self.email, password=self.password)
         self.assertEquals(self.user, auth)
+        # Invalid username should be ignored
+        auth = authenticate(email=self.email, password=self.password,
+                            username='invalid')
+        self.assertEquals(self.user, auth)
 
     def test_user_emails_are_unique(self):
         with self.assertRaises(IntegrityError) as ctx:


### PR DESCRIPTION
Fixes to pull request #45.
