### PR TITLE
Allow users to be created with explicit public keys.

### DIFF
--- a/emailusernames/models.py
+++ b/emailusernames/models.py
@@ -20,11 +20,14 @@ def user_init_patch(self, *args, **kwargs):
 def user_save_patch(self, *args, **kwargs):
     email_as_username = (self.username.lower() == self.email.lower())
     if self.pk is not None:
-        old_user = self.__class__.objects.get(pk=self.pk)
-        email_as_username = (
-            email_as_username or
-            ('@' in self.username and old_user.username == old_user.email)
-        )
+        try:
+            old_user = self.__class__.objects.get(pk=self.pk)
+            email_as_username = (
+                email_as_username or
+                ('@' in self.username and old_user.username == old_user.email)
+            )
+        except self.__class__.DoesNotExist:
+            pass
 
     if email_as_username:
         self.username = _email_to_username(self.email)

--- a/emailusernames/tests.py
+++ b/emailusernames/tests.py
@@ -25,6 +25,14 @@ class CreateUserTests(TestCase):
         user = create_user(self.email, self.password)
         self.assertEquals(user.email, self.email)
 
+    def test_can_create_user_with_explicit_id(self):
+        """Regression test for
+        https://github.com/dabapps/django-email-as-username/issues/52
+
+        """
+        User.objects.create(email=self.email, id=1)
+
+
 
 class ExistingUserTests(TestCase):
     """


### PR DESCRIPTION
Fixes https://github.com/dabapps/django-email-as-username/issues/52
