### PR TITLE
Make createsuperuser command work with Django 1.6

### DIFF
--- a/emailusernames/management/commands/createsuperuser.py
+++ b/emailusernames/management/commands/createsuperuser.py
@@ -10,11 +10,18 @@ from optparse import make_option
 from django.contrib.auth.models import User
 from django.core import exceptions
 from django.core.management.base import BaseCommand, CommandError
-from django.core.validators import email_re
 from django.utils.translation import ugettext as _
 from emailusernames.utils import get_user, create_superuser
 
 def is_valid_email(value):
+    # copied from https://github.com/django/django/blob/1.5.1/django/core/validators.py#L98
+    email_re = re.compile(
+    r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*"  # dot-atom
+    # quoted-string, see also http://tools.ietf.org/html/rfc2822#section-3.2.5
+    r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"'
+    r')@((?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)$)'  # domain
+    r'|\[(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\]$', re.IGNORECASE)  # literal form, ipv4 address (SMTP 4.1.3)
+
     if not email_re.search(value):
         raise exceptions.ValidationError(_('Enter a valid e-mail address.'))
 


### PR DESCRIPTION
Django 1.6 dropped email_re, a regular expression to validate email addresses, so
we just include it directly. Fixes #54.
