### PR TITLE
Remove deprecated call in forms

### DIFF
--- a/emailusernames/forms.py
+++ b/emailusernames/forms.py
@@ -35,7 +35,6 @@ class EmailAuthenticationForm(AuthenticationForm):
                 raise forms.ValidationError(self.message_incorrect_password)
             if not self.user_cache.is_active:
                 raise forms.ValidationError(self.message_inactive)
-        self.check_for_test_cookie()
         return self.cleaned_data
 
 
@@ -64,7 +63,6 @@ class EmailAdminAuthenticationForm(AdminAuthenticationForm):
                 raise forms.ValidationError(self.message_inactive)
             if not self.user_cache.is_staff:
                 raise forms.ValidationError(self.message_restricted)
-        self.check_for_test_cookie()
         return self.cleaned_data
 
 


### PR DESCRIPTION
This was deprecated in 1.7 https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-1-7